### PR TITLE
Allow defining fields with missing values

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Sample model:
 ```ruby
   class FooBar < Dry::ElasticModel::Base
     field :text_field, :text
+    field :newly_added_text_field, :text, allow_missing: true
     field :keyword_field, :keyword, index: false
     field :date_field, :date
     field :long_field, :long
@@ -55,6 +56,10 @@ This corresponds to following Elasticsearch mapping (calling `Foo.mapping.to_jso
   "foobar": {
     "properties": {
       "text_field": {
+        "type": "text",
+        "index": "not_analyzed"
+      },
+      "newly_added_text_field": {
         "type": "text",
         "index": "not_analyzed"
       },

--- a/lib/dry/elastic_model/attributes.rb
+++ b/lib/dry/elastic_model/attributes.rb
@@ -4,6 +4,7 @@ module Dry
   module ElasticModel
     module Attributes
       def field(name, type, opts = {})
+        allow_missing = opts.delete(:allow_missing)
         type_definition = Types::TYPES.fetch(type.to_sym)
 
         type_options_klass = type_definition.meta[:type_options]
@@ -15,26 +16,54 @@ module Dry
                   end
 
         default_opts = type_definition.meta[:opts] || {}
-        attribute(name,
-                  type_definition.meta(opts: default_opts.merge(options.to_h)))
+        define_attribute(
+          name,
+          type_definition.meta(opts: default_opts.merge(options.to_h)),
+          allow_missing: allow_missing
+        )
       end
 
       def range(name, type, opts = {})
+        allow_missing = allow_missing
         member = Types::RANGE_TYPES.fetch(type.to_sym)
 
         type_definition = Types::Range.call(member)
 
         default_opts = type_definition.meta[:opts] || {}
-        attribute(name, type_definition.meta(opts: default_opts.merge(opts)))
+        define_attribute(
+          name,
+          type_definition.meta(opts: default_opts.merge(opts)),
+          allow_missing: opts[:allow_missing]
+        )
       end
 
       def list(name, type, opts = {})
+        allow_missing = opts.delete(:allow_missing)
         member = Types::TYPES.fetch(type.to_sym)
 
         type_definition = Types::Array.call(member)
 
         default_opts = type_definition.meta[:opts] || {}
-        attribute(name, type_definition.meta(opts: default_opts.merge(opts)))
+        define_attribute(
+          name,
+          type_definition.meta(opts: default_opts.merge(opts)),
+          allow_missing: allow_missing
+        )
+      end
+
+      private
+
+      def define_attribute(name, type_definition, allow_missing:)
+        public_send(
+          attr_definition_method(allow_missing),
+          name,
+          type_definition
+        )
+      end
+
+      def attr_definition_method(allow_missing)
+        allow_missing = false if allow_missing.nil?
+        allow_missing ? :attribute? : :attribute
       end
     end
   end

--- a/spec/dry/elastic_model/attributes_spec.rb
+++ b/spec/dry/elastic_model/attributes_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Dry::ElasticModel::Attributes do
+  it "requires all keys to be present by default" do
+    expect do
+      Class.new(Dry::ElasticModel::Base) do
+        field :foo, :text
+        field :bar, :text
+      end.new(foo: "x")
+    end.to raise_error(/:bar is missing in Hash input/)
+  end
+
+  it "accepts null values by default" do
+    a = { foo: nil, bar: nil }
+    v = Class.new(Dry::ElasticModel::Base) do
+      field :foo, :text
+      field :bar, :text
+    end.new(a)
+
+    expect(v.attributes).to eq(a)
+  end
+
+  it "allows defining missing keys" do
+    v = Class.new(Dry::ElasticModel::Base) do
+      field :foo, :text, allow_missing: true
+      range :bar, :integer, allow_missing: true
+      list :baz, :text, allow_missing: true
+      field :zee, :text
+    end.new(zee: "x")
+
+    expect(v.attributes).to eq(zee: "x")
+    expect(v.foo).to eq(nil)
+  end
+end


### PR DESCRIPTION
It may be useful e.g. when adding a new field to the index and older document's are
missing it.