### PR TITLE
Object type should be able to be optional i.e. nil

### DIFF
--- a/lib/dry/elastic_model/types.rb
+++ b/lib/dry/elastic_model/types.rb
@@ -98,8 +98,8 @@ module Dry
                       type_options: TypeOptions::Range)
       end
 
-      ObjectType = Types::Strict::Hash.meta(es_name: "object",
-                                            type_options: TypeOptions::Object)
+      ObjectType = Types::Strict::Hash.optional.meta(es_name: "object",
+                                                     type_options: TypeOptions::Object)
 
       TYPES = {
         text: Text,

--- a/spec/dry/elastic_model/types_spec.rb
+++ b/spec/dry/elastic_model/types_spec.rb
@@ -489,7 +489,7 @@ RSpec.describe Dry::ElasticModel::Types do
     subject(:type) { described_class::ObjectType }
 
     include_examples "type", "object"
-    include_examples "null not allowed"
+    include_examples "null allowed"
 
     it "accepts objects" do
       expect { type[{}] }.not_to raise_error


### PR DESCRIPTION
It's quite often that we have defined inside the index template a field of type object that doesn't have any content i.e. it's nil. Would this change make sense then?